### PR TITLE
Remove red border around hyperlinks from hyperref package

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -34,7 +34,7 @@
 \usepackage{chemarr} %% Useful for one reaction arrow, useless if you're not a chem major
 \usepackage[hyphens]{url}
 % Added by CII
-\usepackage{hyperref}
+\usepackage[colorlinks=true, urlcolor=blue, pdfborder={0 0 0}]{hyperref}
 \usepackage{lmodern}
 \usepackage{float}
 \floatplacement{figure}{H}


### PR DESCRIPTION
Solution found on https://tex.stackexchange.com/questions/823/remove-ugly-borders-around-clickable-cross-references-and-hyperlinks

Looks like it may spawn a few verbose tex errors, but that may be happening without this change as well. 